### PR TITLE
Feature to automatically disable Auto-Retry when reaching a new best percentage, and optionally on testmode

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,7 +3,7 @@ A mod that turns off auto-retry after a set percentage.
 
 # Features
 - A set percentage to turn off auto-retry, which can be changed in the mod settings menu or through a popup in the pause menu
-  - Can be set to work with new bests instead and Testmode
+  - Can be set to work with new bests and Testmode
 
 # Gallery
 ![Settings Popup](./resources/settings-popup.png)

--- a/README.md
+++ b/README.md
@@ -3,6 +3,7 @@ A mod that turns off auto-retry after a set percentage.
 
 # Features
 - A set percentage to turn off auto-retry, which can be changed in the mod settings menu or through a popup in the pause menu
+  - Can be set to work with new bests instead and Testmode
 
 # Gallery
 ![Settings Popup](./resources/settings-popup.png)

--- a/about.md
+++ b/about.md
@@ -3,7 +3,7 @@ A mod that turns off auto-retry after a set percentage.
 
 # Features
 - A set percentage to turn off auto-retry, which can be changed in the mod settings menu or through a popup in the pause menu
-  - Can be set to work with new bests instead and Testmode
+  - Can be set to work with new bests and Testmode
 
 # Gallery
 ![Settings Popup](hiimjustin000.auto_no_auto_retry/settings-popup.png?scale=0.9)

--- a/about.md
+++ b/about.md
@@ -5,4 +5,4 @@ A mod that turns off auto-retry after a set percentage.
 - A set percentage to turn off auto-retry, which can be changed in the mod settings menu or through a popup in the pause menu
 
 # Gallery
-![Settings Popup](hiimjustin000.auto_no_auto_retry/settings-popup.png&scale:0.9)
+![Settings Popup](hiimjustin000.auto_no_auto_retry/settings-popup.png?scale=0.9)

--- a/about.md
+++ b/about.md
@@ -3,6 +3,7 @@ A mod that turns off auto-retry after a set percentage.
 
 # Features
 - A set percentage to turn off auto-retry, which can be changed in the mod settings menu or through a popup in the pause menu
+  - Can be set to work with new bests instead and Testmode
 
 # Gallery
 ![Settings Popup](hiimjustin000.auto_no_auto_retry/settings-popup.png?scale=0.9)

--- a/changelog.md
+++ b/changelog.md
@@ -1,5 +1,5 @@
 # Auto No Auto-Retry Changelog
-## v1.2.0 (2025-06-04)
+## v1.1.0 (2025-06-04)
 - Added setting to instead work with new bests
 - Added setting to work when playing with a start pos
 

--- a/changelog.md
+++ b/changelog.md
@@ -1,4 +1,8 @@
 # Auto No Auto-Retry Changelog
+## v1.2.0 (2025-06-04)
+- Added setting to instead work with new bests
+- Added setting to work when playing with a start pos
+
 ## v1.0.4 (2025-04-07)
 - Added support for iOS
 - Added node IDs to the settings popup

--- a/mod.json
+++ b/mod.json
@@ -10,7 +10,7 @@
     "id": "hiimjustin000.auto_no_auto_retry",
     "name": "Auto No Auto-Retry",
     "developer": "hiimjasmine00",
-    "description": "A mod that turns off auto-retry after a set percentage.",
+    "description": "Turns off auto-retry after a set percentage.",
     "settings": {
         "enable": {
             "name": "Enable",
@@ -24,13 +24,22 @@
             "type": "int",
             "default": 100,
             "min": 0,
-            "max": 100
+            "max": 100,
+            "enable-if": "enable"
         },
         "new-best": {
             "name": "On New Best",
             "description": "Turn off auto-retry when reaching a new best percentage in normal mode. This will override the manual percentage setting.",
             "type": "bool",
-            "default": false
+            "default": false,
+            "enable-if": "enable"
+        },
+        "start-pos": {
+            "name": "Include Testmode",
+            "description": "Turn off auto-retry even when playing from a Start Pos.",
+            "type": "bool",
+            "default": false,
+            "enable-if": "enable"
         }
     },
     "resources": {

--- a/mod.json
+++ b/mod.json
@@ -10,7 +10,7 @@
     "id": "hiimjustin000.auto_no_auto_retry",
     "name": "Auto No Auto-Retry",
     "developer": "hiimjasmine00",
-    "description": "Turn off auto-retry after a set percentage.",
+    "description": "A mod that turns off auto-retry after a set percentage.",
     "settings": {
         "enable": {
             "name": "Enable",
@@ -28,7 +28,7 @@
         },
         "new-best": {
             "name": "On New Best",
-            "description": "Turn off auto-retry when reaching a new best. This will override the percentage setting.",
+            "description": "Turn off auto-retry when reaching a new best percentage in normal mode. This will override the manual percentage setting.",
             "type": "bool",
             "default": false
         }

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
         "mac": "2.2074",
         "ios": "2.2074"
     },
-    "version": "v1.2.0",
+    "version": "v1.1.0",
     "id": "hiimjustin000.auto_no_auto_retry",
     "name": "Auto No Auto-Retry",
     "developer": "hiimjasmine00",
@@ -29,7 +29,7 @@
         },
         "new-best": {
             "name": "On New Best",
-            "description": "Turn off auto-retry when reaching a new best percentage in normal mode. This will override the manual percentage setting.",
+            "description": "Turn off auto-retry when reaching a new best percentage in normal mode. <cr>This will override the manual percentage setting.</c>",
             "type": "bool",
             "default": false,
             "enable-if": "enable"

--- a/mod.json
+++ b/mod.json
@@ -6,7 +6,7 @@
         "mac": "2.2074",
         "ios": "2.2074"
     },
-    "version": "v1.0.4",
+    "version": "v1.2.0",
     "id": "hiimjustin000.auto_no_auto_retry",
     "name": "Auto No Auto-Retry",
     "developer": "hiimjasmine00",

--- a/mod.json
+++ b/mod.json
@@ -1,5 +1,5 @@
 {
-    "geode": "4.3.1",
+    "geode": "4.5.0",
     "gd": {
         "android": "2.2074",
         "win": "2.2074",
@@ -10,7 +10,7 @@
     "id": "hiimjustin000.auto_no_auto_retry",
     "name": "Auto No Auto-Retry",
     "developer": "hiimjasmine00",
-    "description": "A mod that turns off auto-retry after a set percentage.",
+    "description": "Turn off auto-retry after a set percentage.",
     "settings": {
         "enable": {
             "name": "Enable",
@@ -25,6 +25,12 @@
             "default": 100,
             "min": 0,
             "max": 100
+        },
+        "new-best": {
+            "name": "On New Best",
+            "description": "Turn off auto-retry when reaching a new best. This will override the percentage setting.",
+            "type": "bool",
+            "default": false
         }
     },
     "resources": {

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -41,16 +41,22 @@ class $modify(ANARPlayLayer, PlayLayer) {
        
         auto GM = GameManager::get();
         auto autoRetryEnabled = GM->getGameVariable("0026");
-        
-        // checks if new best option is enabled, if so, sets the m_level field to the current level
-        (mod->getSettingValue<bool>("new-best")) ? m_fields->m_level = PlayLayer::get()->m_level : m_fields->m_level = nullptr;
 
         if (!autoRetryEnabled) {
             PlayLayer::destroyPlayer(player, object);
             return;
         }
 
-        // checks if m_level field exists and if not, uses the percent setting (defaults to 1 if m_level is valid)
+        // checks if new best option is enabled, if so, sets the m_level field to the current level
+        if (mod->getSettingValue<bool>("new-best")) {
+            log::info("Playing level with new best setting enabled");
+            m_fields->m_level = PlayLayer::get()->m_level;
+        } else {
+            log::warn("Playing level with new best setting disabled");
+            m_fields->m_level = nullptr;
+        }
+
+        // checks if m_level field exists and if not, uses the percent setting (defaults to 1% if m_level is valid)
         auto setPercentage = m_fields->m_level
                                  ? (m_fields->m_level->m_normalPercent.value() == 0 ? 1 : m_fields->m_level->m_normalPercent.value())
                                  : as<int>(mod->getSettingValue<int64_t>("percentage"));

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -56,9 +56,9 @@ class $modify(ANARPlayLayer, PlayLayer) {
             m_fields->m_level = nullptr;
         }
 
-        // checks if m_level field exists and if not, uses the percent setting (defaults to 1% if using new best setting)
+        // checks if m_level field exists and if not, uses the percent setting
         auto setPercentage = m_fields->m_level
-                                 ? (m_fields->m_level->m_normalPercent.value() == 0 ? 1 : m_fields->m_level->m_normalPercent.value())
+                                 ? m_fields->m_level->m_normalPercent.value()
                                  : as<int>(mod->getSettingValue<int64_t>("percentage"));
         auto startPosIsOk = player->m_isStartPos ? player->m_isStartPos && mod->getSettingValue<bool>("start-pos") : true; // if the player wants no auto retry on startpos
 

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -54,7 +54,7 @@ class $modify(ANARPlayLayer, PlayLayer) {
         auto setPercentage = m_fields->m_level
                                  ? (m_fields->m_level->m_normalPercent.value() == 0 ? 1 : m_fields->m_level->m_normalPercent.value())
                                  : as<int>(mod->getSettingValue<int64_t>("percentage"));
-        auto startPosIsOk = player->m_isStartPos && mod->getSettingValue<bool>("start-pos"); // if the player wants no auto retry on startpos
+        auto startPosIsOk = player->m_isStartPos ? player->m_isStartPos && mod->getSettingValue<bool>("start-pos") : true; // if the player wants no auto retry on startpos
 
         if ((!m_isPracticeMode && !player->m_isPlatformer && startPosIsOk) && (getCurrentPercentInt() >= setPercentage))
             GM->setGameVariable("0026", false);

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -47,7 +47,7 @@ class $modify(ANARPlayLayer, PlayLayer) {
             return;
         }
 
-        // checks if new best option is enabled, if so, sets the m_level field to the current level
+        // checks if new best option is enabled - if so, sets the m_level field to the current level
         if (mod->getSettingValue<bool>("new-best")) {
             log::info("Playing level with new best setting enabled");
             m_fields->m_level = this->m_level;
@@ -56,7 +56,7 @@ class $modify(ANARPlayLayer, PlayLayer) {
             m_fields->m_level = nullptr;
         }
 
-        // checks if m_level field exists and if not, uses the percent setting
+        // checks if m_level field exists - if not, uses the percent setting
         auto setPercentage = m_fields->m_level
                                  ? m_fields->m_level->m_normalPercent.value()
                                  : as<int>(mod->getSettingValue<int64_t>("percentage"));

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -50,19 +50,19 @@ class $modify(ANARPlayLayer, PlayLayer) {
         // checks if new best option is enabled, if so, sets the m_level field to the current level
         if (mod->getSettingValue<bool>("new-best")) {
             log::info("Playing level with new best setting enabled");
-            m_fields->m_level = PlayLayer::get()->m_level;
+            m_fields->m_level = this->m_level;
         } else {
             log::warn("Playing level with new best setting disabled");
             m_fields->m_level = nullptr;
         }
 
-        // checks if m_level field exists and if not, uses the percent setting (defaults to 1% if m_level is valid)
+        // checks if m_level field exists and if not, uses the percent setting (defaults to 1% if using new best setting)
         auto setPercentage = m_fields->m_level
                                  ? (m_fields->m_level->m_normalPercent.value() == 0 ? 1 : m_fields->m_level->m_normalPercent.value())
                                  : as<int>(mod->getSettingValue<int64_t>("percentage"));
         auto startPosIsOk = player->m_isStartPos ? player->m_isStartPos && mod->getSettingValue<bool>("start-pos") : true; // if the player wants no auto retry on startpos
 
-        if ((!m_isPracticeMode && !player->m_isPlatformer && startPosIsOk) && (getCurrentPercentInt() >= setPercentage))
+        if ((!m_isPracticeMode && !player->m_isPlatformer && startPosIsOk) && (this->getCurrentPercentInt() >= setPercentage))
             GM->setGameVariable("0026", false);
 
         PlayLayer::destroyPlayer(player, object);

--- a/src/hooks/PlayLayer.cpp
+++ b/src/hooks/PlayLayer.cpp
@@ -43,17 +43,20 @@ class $modify(ANARPlayLayer, PlayLayer) {
         auto autoRetryEnabled = GM->getGameVariable("0026");
         
         // checks if new best option is enabled, if so, sets the m_level field to the current level
-        if (mod->getSettingValue<bool>("new-best")) m_fields->m_level = PlayLayer::get()->m_level;
+        (mod->getSettingValue<bool>("new-best")) ? m_fields->m_level = PlayLayer::get()->m_level : m_fields->m_level = nullptr;
 
         if (!autoRetryEnabled) {
             PlayLayer::destroyPlayer(player, object);
             return;
         }
 
-        // checks if m_level field exists and if not, uses the percent setting
-        auto setPercentage = m_fields->m_level ? m_fields->m_level->m_normalPercent.value() : as<int>(mod->getSettingValue<int64_t>("percentage"));
+        // checks if m_level field exists and if not, uses the percent setting (defaults to 1 if m_level is valid)
+        auto setPercentage = m_fields->m_level
+                                 ? (m_fields->m_level->m_normalPercent.value() == 0 ? 1 : m_fields->m_level->m_normalPercent.value())
+                                 : as<int>(mod->getSettingValue<int64_t>("percentage"));
+        auto startPosIsOk = player->m_isStartPos && mod->getSettingValue<bool>("start-pos"); // if the player wants no auto retry on startpos
 
-        if (!m_isPracticeMode && !player->m_isPlatformer && getCurrentPercentInt() >= setPercentage)
+        if ((!m_isPracticeMode && !player->m_isPlatformer && startPosIsOk) && (getCurrentPercentInt() >= setPercentage))
             GM->setGameVariable("0026", false);
 
         PlayLayer::destroyPlayer(player, object);


### PR DESCRIPTION
A setting (`new-best`) was added to toggle disabling auto-retry when the player reaches a new best. This overrides the manual `percentage` setting. In `destroyPlayer()`, the mod accesses the seed value under the level's `m_normalPercent` field to compare with the current percentage the player crashed at. Added another setting (`start-pos`) to toggle functionality even when playing the level on Testmode.

### Changes
- Created a **`Fields`** struct and added an `m_level` field to **`PlayLayer`** that defaults to *`nullptr`*
  - `m_level` is only set to a `GJGameLevel` pointer when the `new-best` option is enabled, otherwise it is strictly set to `nullptr`
- Checks for `start-pos` setting if Testmode is on to allow functionality
- Set `enable-if` to *`enable`* setting on all mod settings
- Fixed gallery sprite not appearing in-game